### PR TITLE
Fix Camera NaN Issue and Add Reset Button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Canvas } from '@react-three/fiber'
 import SceneRoot from './scene/SceneRoot'
 import PanelOverlay from './panels/PanelOverlay'
 import HelpButton from './panels/HelpButton'
+import ResetButton from './panels/ResetButton'
 import { DevHud } from './scene/DevTools'
 import { OVERVIEW_CAMERA } from './types/sections'
 
@@ -90,6 +91,8 @@ export default function App() {
         <PanelOverlay />
         {/* ヘルプボタン: 左下に固定表示 */}
         <HelpButton />
+        {/* リセットボタン: ヘルプボタンの上に表示 */}
+        <ResetButton />
         {/* 開発環境のみ: カメラ座標 HUD */}
         <DevHud />
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -341,6 +341,35 @@ body {
   color: white;
 }
 
+/* ===== Reset Button ===== */
+.reset-btn {
+  position: fixed;
+  bottom: 4.5rem; /* HelpButtonの上に配置 */
+  left: 1.5rem;
+  z-index: 20;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(15, 15, 20, 0.75);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s, border-color 0.2s, color 0.2s;
+}
+
+.reset-btn:hover {
+  background: rgba(100, 108, 255, 0.3);
+  border-color: rgba(100, 108, 255, 0.6);
+  color: white;
+}
+
 /* ===== Help Backdrop ===== */
 .help-backdrop {
   position: fixed;

--- a/src/index.css
+++ b/src/index.css
@@ -311,14 +311,15 @@ body {
   font-weight: 700;
 }
 
-/* ===== Help Button ===== */
-.help-btn {
+/* ===== Floating Action Buttons (Help & Reset) ===== */
+.help-btn,
+.reset-btn {
   position: fixed;
-  bottom: 1.5rem;
   left: 1.5rem;
   z-index: 20;
   width: 40px;
   height: 40px;
+  padding: 0;
   border-radius: 50%;
   border: 1px solid rgba(255, 255, 255, 0.25);
   background: rgba(15, 15, 20, 0.75);
@@ -332,42 +333,25 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.2s, border-color 0.2s, color 0.2s;
+  transition:
+    background 0.2s,
+    border-color 0.2s,
+    color 0.2s;
 }
 
-.help-btn:hover {
-  background: rgba(100, 108, 255, 0.3);
-  border-color: rgba(100, 108, 255, 0.6);
-  color: white;
-}
-
-/* ===== Reset Button ===== */
-.reset-btn {
-  position: fixed;
-  bottom: 4.5rem; /* HelpButtonの上に配置 */
-  left: 1.5rem;
-  z-index: 20;
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.25);
-  background: rgba(15, 15, 20, 0.75);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  color: rgba(255, 255, 255, 0.75);
-  font-size: 1.1rem;
-  line-height: 1;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background 0.2s, border-color 0.2s, color 0.2s;
-}
-
+.help-btn:hover,
 .reset-btn:hover {
   background: rgba(100, 108, 255, 0.3);
   border-color: rgba(100, 108, 255, 0.6);
   color: white;
+}
+
+.help-btn {
+  bottom: 1.5rem;
+}
+
+.reset-btn {
+  bottom: 4.5rem; /* HelpButtonの上に配置 */
 }
 
 /* ===== Help Backdrop ===== */

--- a/src/panels/ResetButton.tsx
+++ b/src/panels/ResetButton.tsx
@@ -1,5 +1,9 @@
+import { Vector3 } from 'three'
 import { usePortfolioStore } from '../store/usePortfolioStore'
 import { OVERVIEW_CAMERA } from '../types/sections'
+
+const _pos = new Vector3()
+const _tgt = new Vector3()
 
 export default function ResetButton() {
   const setActiveSection = usePortfolioStore((s) => s.setActiveSection)
@@ -13,6 +17,25 @@ export default function ResetButton() {
     // カメラを初期位置にリセット
     const controls = cameraControlsRef?.current
     if (controls) {
+      // 異常値 (NaN) チェック
+      controls.getPosition(_pos)
+      controls.getTarget(_tgt)
+      const isInvalid = [_pos.x, _pos.y, _pos.z, _tgt.x, _tgt.y, _tgt.z].some(isNaN)
+
+      if (isInvalid) {
+        // すでに NaN の場合はアニメーションさせずに即座にリセット
+        controls.setLookAt(
+          OVERVIEW_CAMERA.position[0],
+          OVERVIEW_CAMERA.position[1],
+          OVERVIEW_CAMERA.position[2],
+          OVERVIEW_CAMERA.target[0],
+          OVERVIEW_CAMERA.target[1],
+          OVERVIEW_CAMERA.target[2],
+          false // 即時
+        )
+        return
+      }
+
       setTransitioning(true)
       controls
         .setLookAt(
@@ -28,7 +51,7 @@ export default function ResetButton() {
           setTransitioning(false)
         })
         .catch(() => {
-          // NaN などで移動に失敗した時のための非常手段
+          // 移動に失敗した時のための非常手段
           controls.reset(false)
           setTransitioning(false)
         })

--- a/src/panels/ResetButton.tsx
+++ b/src/panels/ResetButton.tsx
@@ -1,0 +1,48 @@
+import { usePortfolioStore } from '../store/usePortfolioStore'
+import { OVERVIEW_CAMERA } from '../types/sections'
+
+export default function ResetButton() {
+  const setActiveSection = usePortfolioStore((s) => s.setActiveSection)
+  const cameraControlsRef = usePortfolioStore((s) => s.cameraControlsRef)
+  const setTransitioning = usePortfolioStore((s) => s.setTransitioning)
+
+  const handleReset = () => {
+    // セクション選択を解除
+    setActiveSection(null)
+
+    // カメラを初期位置にリセット
+    const controls = cameraControlsRef?.current
+    if (controls) {
+      setTransitioning(true)
+      controls
+        .setLookAt(
+          OVERVIEW_CAMERA.position[0],
+          OVERVIEW_CAMERA.position[1],
+          OVERVIEW_CAMERA.position[2],
+          OVERVIEW_CAMERA.target[0],
+          OVERVIEW_CAMERA.target[1],
+          OVERVIEW_CAMERA.target[2],
+          true // スムーズに移動
+        )
+        .then(() => {
+          setTransitioning(false)
+        })
+        .catch(() => {
+          // NaN などで移動に失敗した時のための非常手段
+          controls.reset(false)
+          setTransitioning(false)
+        })
+    }
+  }
+
+  return (
+    <button
+      className="reset-btn"
+      onClick={handleReset}
+      aria-label="カメラを初期位置にリセット"
+      title="視点をリセット"
+    >
+      🏠
+    </button>
+  )
+}

--- a/src/scene/CameraController.tsx
+++ b/src/scene/CameraController.tsx
@@ -86,6 +86,8 @@ export default function CameraController() {
       // ── 境界の反発係数 ──────────────────────────────────────────────────────
       // 0 = 硬い壁, 1 = 完全に弾む。0.15 で柔らかく止まる感触
       boundaryFriction={0.15}
+      // カメラ自身を境界ボックス内に収める (壁抜け防止 & NaN 対策)
+      boundaryEnclosesCamera={true}
       // ── ズームをカーソル位置に向かうようにする ───────────────────────────
       dollyToCursor
     />


### PR DESCRIPTION
This PR addresses the issue where the camera would occasionally enter a `NaN` state during right-click translation, rendering it unresponsive. 

### Changes:
1.  **NaN Issue Fix**: In `src/scene/CameraController.tsx`, the `boundaryEnclosesCamera={true}` prop was added to the `CameraControls` component. This ensures the camera position is strictly constrained within the defined `ROOM_BOUNDARY`, preventing calculation errors that lead to `NaN` values when the camera's target hits the boundary during translation (trucking).
2.  **Reset Button**: A new `ResetButton` component was created (`src/panels/ResetButton.tsx`). It provides a one-click way to return the camera to its initial `OVERVIEW_CAMERA` position and target, while also clearing any active portfolio section.
3.  **UI Integration**: The reset button (🏠) is now placed in the bottom-left corner of the screen, just above the help button.
4.  **Error Handling**: The reset logic includes a fallback `controls.reset(false)` call to ensure the camera can be recovered even if it's already in a broken state.

Verified the fix and new UI component with a build check and visual verification.

Fixes #2

---
*PR created automatically by Jules for task [18175416007104488029](https://jules.google.com/task/18175416007104488029) started by @NIRANKEN*