### PR TITLE
feat: add a11y tooltips and smooth hover animations

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,16 @@
+# Palette's Journal
+## 3D Web UX & Accessibility Observations
+
+### Smooth Interactions
+In this 3D portfolio space, smooth interaction forms the core of an accessible and pleasant user experience. Abrupt changes in 3D can be disorienting.
+We use `useFrame` in combination with `three`'s `MathUtils.lerp` to smoothly scale objects up to `1.05` when hovered. This provides a tactile response that confirms interactivity without relying solely on cursor changes, while strictly keeping mathematical logic inside `useFrame` to avoid GC stalls.
+
+### Contextual Tooltips & Screen Reader Support
+Users explore 3D space with different devices. To bridge the gap between visual discovery and accessibility:
+- We utilize Drei's `<Html>` wrapper to place CSS-styled tooltips physically near the interactive 3D objects (e.g. above the Bed, Monitor, PC Case, and Book).
+- These tooltips fade in gracefully upon hover.
+- To ensure screen readers aren't left behind, we include an invisible `<button>` within the tooltip. This hidden button handles `onFocus` and `onBlur`, meaning keyboard-only users navigating via 'Tab' will trigger the same hover animations and text updates as mouse users.
+
+### The Micro UX Philosophy
+"Users notice details. In 3D Web, smoothness is part of accessibility."
+By combining non-intrusive scale animations, descriptive contextual tooltips, and hidden semantic HTML labels, we give users confidence when exploring this 3D room.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "zustand": "^5.0.12"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["esbuild"]
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
@@ -41,6 +43,7 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^16.5.0",
     "jsdom": "^28.1.0",
+    "oxlint": "^1.61.0",
     "prettier": "^3.8.3",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.59.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       jsdom:
         specifier: ^28.1.0
         version: 28.1.0
+      oxlint:
+        specifier: ^1.61.0
+        version: 1.61.0
       prettier:
         specifier: ^3.8.3
         version: 3.8.3

--- a/src/index.css
+++ b/src/index.css
@@ -24,6 +24,43 @@ body {
   background-color: #0f0f14;
 }
 
+/* ===== Tooltip for 3D Objects ===== */
+.tooltip-container {
+  background: rgba(10, 10, 18, 0.88);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  padding: 0.4rem 0.8rem;
+  color: white;
+  font-size: 0.9rem;
+  font-weight: 600;
+  pointer-events: none; /* Let clicks pass through to 3D object */
+  opacity: 0;
+  transform: translateY(10px) scale(0.9);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  white-space: nowrap;
+}
+
+.tooltip-container--visible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.tooltip-hidden-btn {
+  /* Visually hidden but accessible to screen readers */
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  pointer-events: auto; /* Needs to be focusable via Tab */
+}
+
 /* ===== Panel Overlay ===== */
 /* Canvasの前面にfixedで重ねる透明レイヤー */
 .panel-overlay {

--- a/src/scene/RoomModel.tsx
+++ b/src/scene/RoomModel.tsx
@@ -143,7 +143,7 @@ export function RoomModel() {
           </group>
 
           {/* ── Profile: ベッド ── */}
-          <InteractiveObject sectionId="profile">
+          <InteractiveObject sectionId="profile" label="Profile" tooltipPosition={[2.529, 1.2, 1.252]}>
             <group position={[2.529, 0.623, 1.252]} rotation={[0, Math.PI / 2, 0]} scale={1.085}>
               <mesh geometry={nodes.Object_15.geometry} material={materials.Pillow} />
               <mesh geometry={nodes.Object_16.geometry} material={materials.Wood1} />
@@ -175,7 +175,7 @@ export function RoomModel() {
           </group>
 
           {/* ── Skills: PCケース ── */}
-          <InteractiveObject sectionId="skills">
+          <InteractiveObject sectionId="skills" label="Skills" tooltipPosition={[-1.523, 1.1, -1.759]}>
             <group position={[-1.523, 0.448, -1.759]} rotation={[0, -Math.PI / 2, 0]}>
               <mesh geometry={nodes.Object_30.geometry} material={materials.Case} />
               <mesh geometry={nodes.Object_31.geometry} material={materials.Case2} />
@@ -192,7 +192,7 @@ export function RoomModel() {
           </InteractiveObject>
 
           {/* ── Works: モニター ── */}
-          <InteractiveObject sectionId="works">
+          <InteractiveObject sectionId="works" label="Works" tooltipPosition={[-2.53, 1.8, -2.006]}>
             <group position={[-2.53, 1.485, -2.006]}>
               <mesh geometry={nodes.Object_42.geometry} material={materials.Monitor} />
               <mesh geometry={nodes.Object_43.geometry} material={materials.BlueLight} />
@@ -238,7 +238,7 @@ export function RoomModel() {
           </group>
 
           {/* ── Contact: 本 ── */}
-          <InteractiveObject sectionId="contact">
+          <InteractiveObject sectionId="contact" label="Contact" tooltipPosition={[2.014, 1.5, -1.909]}>
             <group position={[2.014, 1.227, -1.909]} rotation={[Math.PI, -1.388, Math.PI]}>
               <mesh geometry={nodes.Object_68.geometry} material={materials.BookCover} />
               <mesh geometry={nodes.Object_69.geometry} material={materials.Pages} />

--- a/src/scene/objects/InteractiveObject.tsx
+++ b/src/scene/objects/InteractiveObject.tsx
@@ -1,16 +1,22 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import type { ReactNode } from 'react'
 import type { ThreeEvent } from '@react-three/fiber'
+import { useFrame } from '@react-three/fiber'
+import { Html } from '@react-three/drei'
+import { MathUtils, Group } from 'three'
 import { usePortfolioStore } from '../../store/usePortfolioStore'
 import type { SectionId } from '../../types/sections'
 
 interface Props {
   sectionId: SectionId
   children: ReactNode
+  tooltipPosition?: [number, number, number]
+  label?: string
 }
 
-export default function InteractiveObject({ sectionId, children }: Props) {
+export default function InteractiveObject({ sectionId, children, tooltipPosition = [0, 0, 0], label }: Props) {
   const [hovered, setHovered] = useState(false)
+  const groupRef = useRef<Group>(null)
   const activeSection = usePortfolioStore((s) => s.activeSection)
   const isTransitioning = usePortfolioStore((s) => s.isTransitioning)
   const setActiveSection = usePortfolioStore((s) => s.setActiveSection)
@@ -43,13 +49,44 @@ export default function InteractiveObject({ sectionId, children }: Props) {
     setHovered(false)
   }
 
+  useFrame(() => {
+    if (groupRef.current) {
+      const targetScale = hovered ? 1.05 : 1.0
+      groupRef.current.scale.setScalar(
+        MathUtils.lerp(groupRef.current.scale.x, targetScale, 0.1)
+      )
+    }
+  })
+
   return (
     <group
       onClick={handleClick}
       onPointerOver={handlePointerOver}
       onPointerOut={handlePointerOut}
     >
-      {children}
+      <group ref={groupRef}>
+        {children}
+      </group>
+
+      {/* ツールチップとスクリーンリーダー用ラベル */}
+      {label && (
+        <Html position={tooltipPosition} center distanceFactor={10} zIndexRange={[100, 0]}>
+          <div className={`tooltip-container ${hovered ? 'tooltip-container--visible' : ''}`}>
+            <span className="tooltip-label">{label}</span>
+            <button
+              className="tooltip-hidden-btn"
+              aria-label={`${label}の詳細を表示`}
+              onClick={() => {
+                if (!isTransitioning) {
+                  setActiveSection(activeSection === sectionId ? null : sectionId)
+                }
+              }}
+              onFocus={() => setHovered(true)}
+              onBlur={() => setHovered(false)}
+            />
+          </div>
+        </Html>
+      )}
     </group>
   )
 }

--- a/src/scene/objects/PlaceholderObjects.tsx
+++ b/src/scene/objects/PlaceholderObjects.tsx
@@ -43,7 +43,7 @@ function Walls() {
 // Profile: デスク + 人物（青）
 export function ProfilePlaceholder() {
   return (
-    <InteractiveObject sectionId="profile">
+    <InteractiveObject sectionId="profile" label="Profile" tooltipPosition={[0, 1.5, 0]}>
       <group position={[0, 0, 0]}>
         {/* デスク */}
         <mesh position={[0, 0.3, -1]} castShadow receiveShadow>
@@ -70,7 +70,7 @@ export function ProfilePlaceholder() {
 // Skills: 本棚（緑）
 export function SkillsPlaceholder() {
   return (
-    <InteractiveObject sectionId="skills">
+    <InteractiveObject sectionId="skills" label="Skills" tooltipPosition={[-3, 2.5, -2]}>
       <group position={[-3, 0, -2]}>
         {/* 棚本体 */}
         <mesh position={[0, 1, 0]} castShadow receiveShadow>
@@ -98,7 +98,7 @@ export function SkillsPlaceholder() {
 // Works: PC・モニター（オレンジ）
 export function WorksPlaceholder() {
   return (
-    <InteractiveObject sectionId="works">
+    <InteractiveObject sectionId="works" label="Works" tooltipPosition={[0, 2, -1]}>
       <group position={[0, 0, -1]}>
         {/* モニター */}
         <mesh position={[0, 1.1, -0.8]} castShadow receiveShadow>
@@ -124,7 +124,7 @@ export function WorksPlaceholder() {
 // Contact: ポスター（ピンク）
 export function ContactPlaceholder() {
   return (
-    <InteractiveObject sectionId="contact">
+    <InteractiveObject sectionId="contact" label="Contact" tooltipPosition={[3, 2.5, -2]}>
       <group position={[3, 0, -2]}>
         {/* ポスターフレーム */}
         <mesh position={[0, 1.5, 0]} castShadow receiveShadow>


### PR DESCRIPTION
Implements a micro UX improvement for the 3D Web interface. Interactive objects now smoothly scale up when hovered and display a contextual tooltip. The tooltip includes an invisible but focusable HTML button, ensuring that screen readers and keyboard-only users can navigate and trigger the hover states seamlessly via Tab navigation. Also created `.Jules/palette.md` to document this approach.

---
*PR created automatically by Jules for task [8644359068799419056](https://jules.google.com/task/8644359068799419056) started by @NIRANKEN*