### PR TITLE
feat: Add navigation menu for quick section access

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import SceneRoot from './scene/SceneRoot'
 import PanelOverlay from './panels/PanelOverlay'
 import HelpButton from './panels/HelpButton'
 import ResetButton from './panels/ResetButton'
+import NavigationMenu from './panels/NavigationMenu'
 import { DevHud } from './scene/DevTools'
 import { INITIAL_ORIENTATION } from './types/sections'
 
@@ -93,6 +94,8 @@ export default function App() {
         <HelpButton />
         {/* リセットボタン: ヘルプボタンの上に表示 */}
         <ResetButton />
+        {/* ナビゲーションメニュー: 左上に表示 */}
+        <NavigationMenu />
         {/* 開発環境のみ: カメラ座標 HUD */}
         <DevHud />
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -539,3 +539,152 @@ body {
   color: rgba(100, 108, 255, 0.9);
   letter-spacing: 0.04em;
 }
+
+/* ===== Navigation Menu ===== */
+.nav-menu-container {
+  position: fixed;
+  top: 1.5rem;
+  left: 1.5rem;
+  z-index: 40;
+}
+
+.nav-btn {
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(15, 15, 20, 0.75);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  color: rgba(255, 255, 255, 0.75);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background 0.2s,
+    border-color 0.2s;
+}
+
+.nav-btn:hover {
+  background: rgba(100, 108, 255, 0.3);
+  border-color: rgba(100, 108, 255, 0.6);
+}
+
+.hamburger-icon {
+  width: 20px;
+  height: 14px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.hamburger-icon span {
+  display: block;
+  width: 100%;
+  height: 2px;
+  background-color: white;
+  border-radius: 2px;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.nav-btn--open .hamburger-icon span:nth-child(1) {
+  transform: translateY(6px) rotate(45deg);
+}
+
+.nav-btn--open .hamburger-icon span:nth-child(2) {
+  opacity: 0;
+}
+
+.nav-btn--open .hamburger-icon span:nth-child(3) {
+  transform: translateY(-6px) rotate(-45deg);
+}
+
+.nav-dropdown {
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  left: 0;
+  width: 240px;
+  background: rgba(10, 10, 18, 0.92);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  overflow: hidden;
+
+  opacity: 0;
+  transform: translateY(-10px) scale(0.95);
+  pointer-events: none;
+  transform-origin: top left;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.nav-dropdown--open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.nav-dropdown__header {
+  padding: 1rem 1rem 0.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  margin-bottom: 0.5rem;
+}
+
+.nav-dropdown__title {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.nav-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 0.5rem 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.nav-list__item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.95rem;
+  font-family: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.2s, color 0.2s;
+}
+
+.nav-list__item:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.08);
+  color: white;
+}
+
+.nav-list__item:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.nav-list__icon {
+  font-size: 1.1rem;
+  width: 1.5rem;
+  text-align: center;
+}
+
+.nav-list__label {
+  font-weight: 500;
+}

--- a/src/panels/NavigationMenu.tsx
+++ b/src/panels/NavigationMenu.tsx
@@ -1,0 +1,82 @@
+import { useState, useRef, useEffect } from 'react'
+import { usePortfolioStore } from '../store/usePortfolioStore'
+import type { SectionId } from '../types/sections'
+
+const NAV_ITEMS: { id: SectionId; label: string; icon: string }[] = [
+  { id: 'profile', label: 'Profile', icon: '👤' },
+  { id: 'skills', label: 'Skills', icon: '💻' },
+  { id: 'works', label: 'Works', icon: '📁' },
+  { id: 'contact', label: 'Contact', icon: '✉️' },
+]
+
+export default function NavigationMenu() {
+  const [isOpen, setIsOpen] = useState(false)
+  const setActiveSection = usePortfolioStore((s) => s.setActiveSection)
+  const isTransitioning = usePortfolioStore((s) => s.isTransitioning)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  // Handle clicking outside to close
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (isOpen && menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [isOpen])
+
+  // Handle Escape key to close menu
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape' && isOpen) {
+        setIsOpen(false)
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen])
+
+  const handleItemClick = (sectionId: SectionId) => {
+    if (!isTransitioning) {
+      setActiveSection(sectionId)
+      setIsOpen(false)
+    }
+  }
+
+  return (
+    <div className="nav-menu-container" ref={menuRef}>
+      <button
+        className={`nav-btn ${isOpen ? 'nav-btn--open' : ''}`}
+        onClick={() => setIsOpen(!isOpen)}
+        aria-label="Toggle navigation menu"
+      >
+        <div className="hamburger-icon">
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
+      </button>
+
+      <div className={`nav-dropdown ${isOpen ? 'nav-dropdown--open' : ''}`}>
+        <div className="nav-dropdown__header">
+          <h3 className="nav-dropdown__title">Menu</h3>
+        </div>
+        <ul className="nav-list">
+          {NAV_ITEMS.map((item) => (
+            <li key={item.id}>
+              <button
+                className="nav-list__item"
+                onClick={() => handleItemClick(item.id)}
+                disabled={isTransitioning}
+              >
+                <span className="nav-list__icon">{item.icon}</span>
+                <span className="nav-list__label">{item.label}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Adds a global Navigation Menu accessible via a hamburger button on the top left of the UI. This allows users to directly navigate to the 'Profile', 'Skills', 'Works', and 'Contact' sections, seamlessly integrating with the existing 3D camera transitions without needing to find the models in the 3D space.

---
*PR created automatically by Jules for task [8184164635082721211](https://jules.google.com/task/8184164635082721211) started by @NIRANKEN*