### PR TITLE
Feat: Improve UX and A11y for Interactive 3D Objects

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-02 - [3D Accessibility & Smooth Feedback]
+**Learning:** In 3D Web applications, abruptly toggling visibility or scale can feel disjointed. Screen readers and keyboard navigation are often overlooked in `<canvas>`, making interactive meshes inaccessible.
+**Action:** Use Drei's `<Html>` to inject visually hidden, focusable DOM elements (like `<button>`) near interactive 3D objects, binding `onFocus` and `onBlur` to 3D hover states. Smoothly transition visual feedback (e.g., highlight material opacity) using `THREE.MathUtils.lerp` inside `useFrame` instead of boolean visibility toggles.

--- a/src/scene/objects/InteractiveObject.tsx
+++ b/src/scene/objects/InteractiveObject.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import * as THREE from "three";
 import { useFrame } from "@react-three/fiber";
 import type { ThreeEvent } from "@react-three/fiber";
+import { Html } from "@react-three/drei";
 import { usePortfolioStore } from "../../store/usePortfolioStore";
 import type { SectionId } from "../../types/sections";
 
@@ -31,7 +32,7 @@ export default function InteractiveObject({ sectionId, children }: Props) {
     return new THREE.MeshBasicMaterial({
       color: 0x0088ff,
       transparent: true,
-      opacity: 0.3,
+      opacity: 0,
       depthWrite: false,
       side: THREE.DoubleSide,
     });
@@ -63,29 +64,35 @@ export default function InteractiveObject({ sectionId, children }: Props) {
     };
   }, [highlightMaterial]);
 
-  // Reactの再レンダリングを避け、useFrameでvisibilityを直接制御
-  useFrame(() => {
+  // Reactの再レンダリングを避け、useFrameでopacityを直接制御
+  useFrame((_, delta) => {
     if (highlightGroupRef.current) {
-      highlightGroupRef.current.visible = hoveredRef.current;
+      const targetOpacity = hoveredRef.current ? 0.3 : 0;
+      highlightMaterial.opacity = THREE.MathUtils.lerp(
+        highlightMaterial.opacity,
+        targetOpacity,
+        10 * delta
+      );
+      highlightGroupRef.current.visible = highlightMaterial.opacity > 0.01;
     }
   });
 
-  function handleClick(e: ThreeEvent<MouseEvent>) {
-    e.stopPropagation();
+  function handleClick(e?: ThreeEvent<MouseEvent> | React.MouseEvent) {
+    e?.stopPropagation();
     if (isTransitioning) return;
     // 同じセクションをクリックするとオーバービューに戻る（トグル）
     setActiveSection(activeSection === sectionId ? null : sectionId);
   }
 
-  function handlePointerOver(e: ThreeEvent<PointerEvent>) {
-    e.stopPropagation();
+  function handlePointerOver(e?: ThreeEvent<PointerEvent> | React.FocusEvent) {
+    e?.stopPropagation();
     if (!hoveredRef.current) {
       hoveredRef.current = true;
       document.body.style.cursor = "pointer";
     }
   }
 
-  function handlePointerOut() {
+  function handlePointerOut(_e?: ThreeEvent<PointerEvent> | React.FocusEvent) {
     hoveredRef.current = false;
     document.body.style.cursor = "auto";
   }
@@ -94,6 +101,17 @@ export default function InteractiveObject({ sectionId, children }: Props) {
     <group onClick={handleClick} onPointerOver={handlePointerOver} onPointerOut={handlePointerOut}>
       <group ref={groupRef}>{children}</group>
       <group ref={highlightGroupRef} />
+
+      {/* アクセシビリティ用: フォーカス可能な隠しボタン */}
+      <Html style={{ opacity: 0, pointerEvents: "none" }}>
+        <button
+          aria-label={`${sectionId}の詳細を表示`}
+          onClick={handleClick}
+          onFocus={handlePointerOver}
+          onBlur={handlePointerOut}
+          style={{ pointerEvents: "auto", width: "1px", height: "1px", border: "none", padding: 0 }}
+        />
+      </Html>
     </group>
   );
 }


### PR DESCRIPTION
This change addresses the prompt by introducing a single micro UX improvement for interactive 3D elements in `InteractiveObject.tsx`:
1. It replaces the abrupt boolean toggle of the highlight group visibility with a smooth opacity transition using `THREE.MathUtils.lerp` inside `useFrame`.
2. It introduces a visually hidden, keyboard-focusable HTML button via Drei's `<Html>` component. This allows screen readers and keyboard users (tabbing) to focus on and interact with the 3D meshes as if they were standard DOM elements, triggering the same hover animations and click actions.

A log was also created in `.Jules/palette.md` noting this pattern for future reference.

---
*PR created automatically by Jules for task [4483231427461216206](https://jules.google.com/task/4483231427461216206) started by @NIRANKEN*