### PR TITLE
feat(a11y): improve 3D space accessibility with keyboard and screen reader support

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,15 @@
+# Palette's Journal
+
+## 3D Spatial UX Quirks & A11y Improvements
+
+**Observation:**
+In a 3D Canvas, purely visual objects (like a `THREE.Mesh` or `<group>`) lack native DOM semantics. While `onClick` or `onPointerOver` on a mesh might work for mouse users, they remain completely invisible to screen readers and inaccessible to keyboard-only users navigating via Tab.
+
+**UX Improvement (A11y):**
+By utilizing `@react-three/drei`'s `<Html>` component, we can embed a visually hidden DOM element (such as `<button className="sr-only">`) within the 3D scene that corresponds to an interactive 3D object.
+
+**Implementation Details:**
+- Added a `<button>` inside an `<Html>` component to `InteractiveObject.tsx`.
+- The button is styled with a `.sr-only` class to ensure it doesn't disrupt the visual flow of the scene but remains accessible in the accessibility tree.
+- Attached `onFocus` and `onBlur` handlers to the button to visually highlight the corresponding 3D object when navigated to via keyboard (Tab).
+- Added `onKeyDown` support for keyboard activations (`Enter` or `Space` key).

--- a/src/index.css
+++ b/src/index.css
@@ -272,6 +272,19 @@ body {
   flex-shrink: 0;
 }
 
+/* Accessibility */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
 /* ===== Dev HUD (開発環境のみ表示) ===== */
 .dev-hud {
   position: fixed;

--- a/src/scene/objects/InteractiveObject.tsx
+++ b/src/scene/objects/InteractiveObject.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import * as THREE from "three";
 import { useFrame } from "@react-three/fiber";
 import type { ThreeEvent } from "@react-three/fiber";
+import { Html } from "@react-three/drei";
 import { usePortfolioStore } from "../../store/usePortfolioStore";
 import type { SectionId } from "../../types/sections";
 
@@ -90,10 +91,42 @@ export default function InteractiveObject({ sectionId, children }: Props) {
     document.body.style.cursor = "auto";
   }
 
+  function handleFocus() {
+    hoveredRef.current = true;
+  }
+
+  function handleBlur() {
+    hoveredRef.current = false;
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      if (isTransitioning) return;
+      setActiveSection(activeSection === sectionId ? null : sectionId);
+    }
+  }
+
   return (
     <group onClick={handleClick} onPointerOver={handlePointerOver} onPointerOut={handlePointerOut}>
       <group ref={groupRef}>{children}</group>
       <group ref={highlightGroupRef} />
+      <Html distanceFactor={10} style={{ opacity: 0, pointerEvents: 'none' }}>
+        <button
+          className="sr-only"
+          aria-label={`${sectionId}の詳細を見る`}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          onClick={(e) => {
+            // Prevent default HTML button click if we trigger via 3D canvas
+            e.stopPropagation();
+            if (isTransitioning) return;
+            setActiveSection(activeSection === sectionId ? null : sectionId);
+          }}
+          style={{ pointerEvents: 'auto' }}
+        />
+      </Html>
     </group>
   );
 }


### PR DESCRIPTION
This PR adds keyboard navigability and screen reader support to 3D canvas `InteractiveObject` elements.

By utilizing `@react-three/drei`'s `<Html>` component, it injects a visually hidden `<button>` matching the interactive sections within the 3D scene. This brings DOM semantics into the WebGL environment. It binds visual hover states directly to the underlying button's `onFocus` and `onBlur` events, allowing keyboard-only users to navigate the 3D items with the standard `Tab` key and activate them with `Enter` or `Space`.

A new journal log at `.Jules/palette.md` was included, capturing this standard method to solve accessibility deficits within 3D Canvas interfaces.

---
*PR created automatically by Jules for task [16533949646640350558](https://jules.google.com/task/16533949646640350558) started by @NIRANKEN*